### PR TITLE
Regex is now only applied to first and last rows of the xml file

### DIFF
--- a/mlapp2classdef.m
+++ b/mlapp2classdef.m
@@ -75,7 +75,7 @@ end
 fclose(fID);
 
 % Strip out header & footer, then save to a *.m file
-A = regexprep(A, '(^.*)(?=classdef)|(?<=end)(\].*$)', '');
+A([1,end]) = regexprep(A([1,end]), '(^.*)(?=classdef)|(?<=end)(\].*$)', '');
 
 fID = fopen(fullfile(pathname, sprintf('%s.m', appname)), 'w');
 for ii = 1:length(A)


### PR DESCRIPTION
The original way it was written caused other lines within the file to be butchered if they contained the word "classdef" in them.
